### PR TITLE
markdown: fix smaller than symbols

### DIFF
--- a/convertors.py
+++ b/convertors.py
@@ -260,6 +260,8 @@ class MarkdownConvertor(ConvertorInterface):
             converted = re.sub("%0a", "\n", converted)
             # Reencode %25 to %
             converted = re.sub("%25", "%", converted)
+            # Reencode %3c to <
+            converted = re.sub("%3c", "<", converted)
 
             # # Table Creations
             converted = re.sub("\\|{2}Border(.*)\n", "", converted, flags=re.IGNORECASE)


### PR DESCRIPTION
After converting a pmwiki instance, many pages had gibberish instead of the smaller than ('<') symbol.

Reencode %3c to <.  Pmwiki encodes < as %3c. When converting to markdown, it needs to be converted back.